### PR TITLE
Fix case of 'viewBox' to 'viewbox' in allowed SVG tags

### DIFF
--- a/inc/Blocks/SvgImage/Caller.php
+++ b/inc/Blocks/SvgImage/Caller.php
@@ -153,7 +153,7 @@ class Caller {
 		return array(
 			'svg'      => array(
 				'xmlns'       => true,
-				'viewBox'     => true,
+				'viewbox'     => true,
 				'width'       => true,
 				'height'      => true,
 				'fill'        => true,


### PR DESCRIPTION
The viewBox tag was being stripped bu wp_kses in the render method. 

> HTML tags and attribute names are case-insensitive in HTML but must be added to the KSES allow list in lowercase.
https://developer.wordpress.org/reference/hooks/wp_kses_allowed_html/

How to test
Try adding a SVG that has a viewBox tag like viewBox="0 0 72 24" in the SVG Code input, SVG Image block.